### PR TITLE
Error packaging with Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
+				<configuration>
+					<source>8</source>
+				</configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
See https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212233.
Altered maven-javadoc-plugin section of pom.xml as suggested.